### PR TITLE
Optional force

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Usage: subpath-as-branch [options]
 
 Options:
   -V, --version         output the version number
-  -p, --path <value>    Target path to submit
-  -b, --branch <value>  Branch name
+  -p, --path <value>    target path to submit
+  -b, --branch <value>  branch name
+  -c, --clean           clean git in subpath
   -h, --help            output usage information
 ```

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,9 +16,7 @@ if (!cli.path || !cli.branch ) {
 // Get the required fields
 const targetPath = cli.path
 const targetBranch = cli.branch
-const forcePush = cli.force
-
-console.log('forcePush', forcePush);
+const forcePush = cli.force ? '-f' : ''
 
 // Step 1: Check if git is supported by the machine's cli
 logger.log('1. Checking for git binary')
@@ -58,9 +56,8 @@ if (gitAddOriginOutput.status !== 0) {
 }
 
 // Step 5. Push branch to github
-logger.log('5. Push branch to github')
-// const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push -f --set-upstream origin ${targetBranch}`)
-const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push --set-upstream origin ${targetBranch}`)
+logger.log('5. Push branch to origin')
+const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push ${forcePush} --set-upstream origin ${targetBranch}`)
 if (gitPushBranchOutput.status !== 0) {
   logger.error(`push branch via git failed for the following reason(s): \n${gitPushBranchOutput.message}`)
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,8 +16,11 @@ if (!cli.path || !cli.branch ) {
 // Get the required fields
 const targetPath = cli.path
 const targetBranch = cli.branch
+const forcePush = cli.force
 
-// Step 1: Check if git is supported by the machine's cli 
+console.log('forcePush', forcePush);
+
+// Step 1: Check if git is supported by the machine's cli
 logger.log('1. Checking for git binary')
 const gitPresence = exec('which git')
 if (gitPresence.status !== 0) {
@@ -56,7 +59,8 @@ if (gitAddOriginOutput.status !== 0) {
 
 // Step 5. Push branch to github
 logger.log('5. Push branch to github')
-const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push -f --set-upstream origin ${targetBranch}`)
+// const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push -f --set-upstream origin ${targetBranch}`)
+const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push --set-upstream origin ${targetBranch}`)
 if (gitPushBranchOutput.status !== 0) {
   logger.error(`push branch via git failed for the following reason(s): \n${gitPushBranchOutput.message}`)
 }

--- a/bin/index.js
+++ b/bin/index.js
@@ -9,7 +9,8 @@ const cli = require('../src/cli')
 // Step 0: Check for presence of compulsory arguments
 cli.parse(process.argv)
 logger.log('0. Checking for required process arguments')
-if (!cli.path || !cli.branch ) {
+
+if (!cli.path || (!cli.branch && !cli.clean)) {
   logger.error(`Invalid command: ${cli.args.join(' ')}\nSee --help for a list of available commands.`)
 }
 
@@ -17,53 +18,56 @@ if (!cli.path || !cli.branch ) {
 const targetPath = cli.path
 const targetBranch = cli.branch
 const forcePush = cli.force ? '-f' : ''
+const needClean = Boolean(cli.clean)
 
-// Step 1: Check if git is supported by the machine's cli
-logger.log('1. Checking for git binary')
-const gitPresence = exec('which git')
-if (gitPresence.status !== 0) {
-  logger.error('git binary is not install. Please install it before using this package')
-}
+if (!needClean) {
+  // Step 1: Check if git is supported by the machine's cli
+  logger.log('1. Checking for git binary')
+  const gitPresence = exec('which git')
+  if (gitPresence.status !== 0) {
+    logger.error('git binary is not install. Please install it before using this package')
+  }
 
-// Step 2: Fetch changes from origin
-logger.log('2. Fetch from origin')
-const gitFetchOutput = exec('git fetch -p origin')
-if (gitFetchOutput.status !== 0) {
-  logger.error(`git fetch failed for the following reason(s): \n${gitFetchOutput.message}`)
-}
+  // Step 2: Fetch changes from origin
+  logger.log('2. Fetch from origin')
+  const gitFetchOutput = exec('git fetch -p origin')
+  if (gitFetchOutput.status !== 0) {
+    logger.error(`git fetch failed for the following reason(s): \n${gitFetchOutput.message}`)
+  }
 
-// Step 3: Get local git config
-logger.log('3. Getting local git config')
-const gitGetRemoteOutput = exec('git remote get-url origin')
-if (gitGetRemoteOutput.status !== 0) {
-  logger.error(`git remote failed for the following reason(s): \n${gitGetRemoteOutput.message}`)
-}
-const gitRemoteUrl = gitGetRemoteOutput.message
 
-// Step 4: Changing context to the directory
-logger.log('4. Building branch subpath context in --path')
-const targetPathOutput = exec(`cd ${targetPath}`)
-if (targetPathOutput.status !== 0) {
-  logger.error(`cd failed for the following reason(s): \n${targetPathOutput.message}`)
-}
-const gitInitOutput = exec(`cd ${targetPath} && git init`)
-if (gitInitOutput.status !== 0) {
-  logger.error(`git init failed for the following reason(s): \n${gitInitOutput.message}`)
-}
-const gitAddOriginOutput = exec(`cd ${targetPath} && git remote add origin ${gitRemoteUrl}`)
-if (gitAddOriginOutput.status !== 0) {
-  logger.error(`git remote failed for the following reason(s): \n${gitAddOriginOutput.message}`)
-}
+  // Step 3: Get local git config
+  logger.log('3. Getting local git config')
+  const gitGetRemoteOutput = exec('git remote get-url origin')
+  if (gitGetRemoteOutput.status !== 0) {
+    logger.error(`git remote failed for the following reason(s): \n${gitGetRemoteOutput.message}`)
+  }
+  const gitRemoteUrl = gitGetRemoteOutput.message
 
-// Step 5. Push branch to github
-logger.log('5. Push branch to origin')
-const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push ${forcePush} --set-upstream origin ${targetBranch}`)
-if (gitPushBranchOutput.status !== 0) {
-  logger.error(`push branch via git failed for the following reason(s): \n${gitPushBranchOutput.message}`)
-}
+  // Step 4: Changing context to the directory
+  logger.log('4. Building branch subpath context in --path')
+  const targetPathOutput = exec(`cd ${targetPath}`)
+  if (targetPathOutput.status !== 0) {
+    logger.error(`cd failed for the following reason(s): \n${targetPathOutput.message}`)
+  }
+  const gitInitOutput = exec(`cd ${targetPath} && git init`)
+  if (gitInitOutput.status !== 0) {
+    logger.error(`git init failed for the following reason(s): \n${gitInitOutput.message}`)
+  }
+  const gitAddOriginOutput = exec(`cd ${targetPath} && git remote add origin ${gitRemoteUrl}`)
+  if (gitAddOriginOutput.status !== 0) {
+    logger.error(`git remote failed for the following reason(s): \n${gitAddOriginOutput.message}`)
+  }
 
+  // Step 5. Push branch to origin
+  logger.log('5. Push branch to origin')
+  const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push ${forcePush} --set-upstream origin ${targetBranch}`)
+  if (gitPushBranchOutput.status !== 0) {
+    logger.error(`push branch via git failed for the following reason(s): \n${gitPushBranchOutput.message}`)
+  }
+}
 // Step 6. Cleanup
-logger.log('6. Remove created git repository and return to original path')
+logger.log(`${needClean ? 1 : 6}. Remove created git repository and return to original path`)
 const rmGit = exec(`cd ${targetPath} && rm -rf .git`)
 if (rmGit.status !== 0) {
   logger.error(`rm hidden git dir failed for the following reason(s): \n${rmGit.message}`)

--- a/bin/index.js
+++ b/bin/index.js
@@ -17,7 +17,7 @@ if (!cli.path || (!cli.branch && !cli.clean)) {
 // Get the required fields
 const targetPath = cli.path
 const targetBranch = cli.branch
-const forcePush = cli.force ? '-f' : ''
+const forceFlag = cli.force ? '-f' : ''
 const needClean = Boolean(cli.clean)
 
 if (!needClean) {
@@ -61,7 +61,7 @@ if (!needClean) {
 
   // Step 5. Push branch to origin
   logger.log('5. Push branch to origin')
-  const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push ${forcePush} --set-upstream origin ${targetBranch}`)
+  const gitPushBranchOutput = exec(`cd ${targetPath} && git checkout -b ${targetBranch} && git add --all && git commit -m 'subpath-as-branch publish' && git push ${forceFlag} --set-upstream origin ${targetBranch}`)
   if (gitPushBranchOutput.status !== 0) {
     logger.error(`push branch via git failed for the following reason(s): \n${gitPushBranchOutput.message}`)
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subpath-as-branch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Publish a directory to a different branch. Useful for static sites / github pages.",
   "bin": {
     "subpath-as-branch": "./bin/index.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,5 +6,6 @@ program
   .option('-p, --path <value>', 'Target path to submit')
   .option('-b, --branch <value>', 'Branch name')
   .option('-f, --force', 'Force push')
+  .option('-c, --clean', 'Clean git in subpath')
 
 module.exports = program

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,5 +5,6 @@ program
   .version('0.0.7')
   .option('-p, --path <value>', 'Target path to submit')
   .option('-b, --branch <value>', 'Branch name')
+  .option('-f, --force', 'Force push')
 
 module.exports = program

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,9 +3,9 @@
 const program = require('commander')
 program
   .version('0.0.7')
-  .option('-p, --path <value>', 'Target path to submit')
-  .option('-b, --branch <value>', 'Branch name')
-  .option('-f, --force', 'Force push')
-  .option('-c, --clean', 'Clean git in subpath')
+  .option('-p, --path <value>', 'target path to submit')
+  .option('-b, --branch <value>', 'branch name')
+  .option('-f, --force', 'force push')
+  .option('-c, --clean', 'clean git in subpath')
 
 module.exports = program


### PR DESCRIPTION
Problem:
Maybe someone like me doesn't want override previous branch.
So I propose make `-f` optional.

Second problem:
If our push failed, folder has `.git`, which we want to delete.
We don't want do this manually.
So I propose to have `-c` or `--clean` as possible option.
For example `subpath-as-branch -p my_path -c` should delete `.git` in folder `my_path`