### PR TITLE
use path as default branch name

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -9,15 +9,15 @@ const cli = require('../src/cli')
 // Step 0: Check for presence of compulsory arguments
 cli.parse(process.argv)
 logger.log('0. Checking for required process arguments')
-if (!cli.path || !cli.branch ) {
+if (!cli.path) {
   logger.error(`Invalid command: ${cli.args.join(' ')}\nSee --help for a list of available commands.`)
 }
 
 // Get the required fields
 const targetPath = cli.path
-const targetBranch = cli.branch
+const targetBranch = cli.branch || targetPath
 
-// Step 1: Check if git is supported by the machine's cli 
+// Step 1: Check if git is supported by the machine's cli
 logger.log('1. Checking for git binary')
 const gitPresence = exec('which git')
 if (gitPresence.status !== 0) {


### PR DESCRIPTION
we can use path as default branch name
for example `subpath-as-branch -p my_path` will create the branch `my_path`